### PR TITLE
(fix): undefined variable: id in RobotSettings

### DIFF
--- a/src/Actions/Api/Metas/RobotSettings.php
+++ b/src/Actions/Api/Metas/RobotSettings.php
@@ -66,10 +66,10 @@ class RobotSettings implements ExecuteHooks
      */
     public function processPut(\WP_REST_Request $request)
     {
-        $metas = MetaRobotSettingsHelper::getMetaKeys($id);
-
         $id     = $request->get_param('id');
         $params = $request->get_params();
+
+        $metas = MetaRobotSettingsHelper::getMetaKeys($id);
 
         try {
 


### PR DESCRIPTION
Following error was thrown while trying to save SEOPress settings in post editor.:
production.ERROR: Undefined variable: id {"exception":"[object] (ErrorException(code: 0): Undefined variable: id at /wp-content/plugins/wp-seopress/src/Actions/Api/Metas/RobotSettings.php:69)