### PR TITLE
Plugin headers: require specific PHP and WP versions

### DIFF
--- a/seopress.php
+++ b/seopress.php
@@ -9,6 +9,8 @@ Author URI: https://www.seopress.org/
 License: GPLv2
 Text Domain: wp-seopress
 Domain Path: /languages
+Requires PHP: 7.2
+Requires at least: 5.0
 */
 
 /*  Copyright 2016 - 2023 - Benjamin Denis  (email : contact@seopress.org)


### PR DESCRIPTION
WordPress Core includes a mechanism to block plugin activations when your site's version of PHP or WP does match the requirements of the plugin. This was implemented as a result of this trac ticket:
https://core.trac.wordpress.org/ticket/43992

This ensures that site owners do not find themselves with Fatal errors on their site after activating a plugin.

The 2 versions I added in that PR match the existing values in the `readme.txt` headers:
https://github.com/wp-seopress/wp-seopress-public/blob/10d04106aab3e7ad5c8b9fd61eb3d5ff0e5e0382/readme.txt#L6-L8

------

For reference, I'm submitting this after a discussion in WordPressFR Slack, following the 6.5.0.3 release in 10d04106aab3e7ad5c8b9fd61eb3d5ff0e5e0382; the release bumps `psr/http-message` to `1.1`, which now requires PHP 7.2.