### PR TITLE
Fix error handling for tags in Facebook OG author hook

### DIFF
--- a/inc/functions/options-social.php
+++ b/inc/functions/options-social.php
@@ -249,7 +249,7 @@ function seopress_social_facebook_og_author_hook() {
 			// article:tag
 			if (function_exists('get_the_tags')) {
 				$tags = get_the_tags();
-				if ( ! empty($tags)) {
+				if ( ! empty($tags) && !is_wp_error($tags)) {
 					$seopress_social_og_tag = '';
 					foreach ($tags as $tag) {
 						$seopress_social_og_tag .= '<meta property="article:tag" content="' . esc_attr($tag->name) . '">';


### PR DESCRIPTION
Added a check to ensure `get_the_tags` does not return a `WP_Error`. This prevents potential issues when generating Facebook Open Graph article tags.